### PR TITLE
Fallback to boto3 authentication mechanisms

### DIFF
--- a/tryton_filestore_s3.py
+++ b/tryton_filestore_s3.py
@@ -42,8 +42,8 @@ def name(id, prefix=''):
     return '/'.join(filter(None, [prefix, id]))
 
 def get_client():
-    access_key = config.get('database', 'access_key', default='')
-    secret_key = config.get('database', 'secret_key', default='')
+    access_key = config.get('database', 'access_key', default=None)
+    secret_key = config.get('database', 'secret_key', default=None)
     bucket = config.get('database', 'bucket')
     client = boto3.client('s3',
         aws_access_key_id     = access_key,


### PR DESCRIPTION
In absence of configured access and secret AWS keys,
passing empty strings instead of None values to boto3.client
prevents it to fallback to secondary authentication mechanisms,
from environment session tokens down to EKS/ECS service roles
or shared credentials, SSO, OIDC providers and whatnot.

https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#credentials